### PR TITLE
Order the rows by hash

### DIFF
--- a/src/blacklist.ts
+++ b/src/blacklist.ts
@@ -58,7 +58,8 @@ export class Blacklist {
     await this.db.each(
       `SELECT * FROM ${
         this.tableName
-      } WHERE lastSeen BETWEEN ${timestampStart} AND ${timestampEnd}`,
+      } WHERE lastSeen BETWEEN ${timestampStart} AND ${timestampEnd}
+      ORDER BY hash`,
       (err: Error, row: IBlacklistItem): void => {
         // Discard the value for 'lastSeen', the client can implicitly use the timestamp
         // when it has fetched them. The loss of resolution is very well acceptable and


### PR DESCRIPTION
While there are no guarantees that the resulting JavaScript object stays
ordered by the key this appears to result in a deterministic and actually
ordered output.

Besides looking better to the human reader this also should improve import
performance by a bit, because new entries are inserted in the UNIQUE index
at the end, instead of being inserted all over the place.